### PR TITLE
Use Eclipse Temurin, not AdoptOpenJDK in action

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -47,9 +47,9 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up JDK 8
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3.0.0
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 8
       - name: Release
         uses: jenkins-infra/jenkins-maven-cd-action@v1.2.0

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -47,7 +47,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up JDK 8
-        uses: actions/setup-java@v3.0.0
+        uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: 8


### PR DESCRIPTION
The 'adopt' distribution has moved to Eclipse Temurin.

It won't be updated at the AdoptOpenJDK location.

See https://github.com/jenkinsci/jenkins/pull/6406

https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#adopt

https://github.com/actions/setup-java#usage

Supersedes #20 